### PR TITLE
Use ARC when compiling (Closes #15)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,5 +6,6 @@ include $(THEOS)/makefiles/common.mk
 
 TWEAK_NAME = LetMeBlock
 LetMeBlock_FILES = Tweak.xm
+LetMeBlock_CFLAGS = -fobjc-arc
 
 include $(THEOS_MAKE_PATH)/tweak.mk


### PR DESCRIPTION
Libhooker does not have a large autoreleasepool for tweaks, so LetMeBlock wouldn't function on Odyssey{,ra1n} until it was compiled with -fobjc-arc.

Tested on an iPhone 11 iOS 13.5 Odyssey. Closes #15 